### PR TITLE
Fix Sections "__getitem__" for index greater than 1.

### DIFF
--- a/holmium/core/pageobject.py
+++ b/holmium/core/pageobject.py
@@ -577,13 +577,10 @@ class Sections(Section, collections.Sequence):
         return len(self.__getelements__())
 
     def __getitem__(self, idx):
-        _idx = 0
-        for _ in self:
-            if idx == _idx:
-                break
-            _idx += 1
-            if idx > _idx:
-                raise IndexError("Sections index (%d) out of range" % idx)
-        if len(self) == 0:
+        if idx < 0 or idx >= len(self):
             raise IndexError("Sections index (%d) out of range" % idx)
+        for i, _ in enumerate(self):
+            if i == idx:
+                break
         return self
+

--- a/tests/sectionobject_tests.py
+++ b/tests/sectionobject_tests.py
@@ -118,6 +118,32 @@ class SectionTest(unittest.TestCase):
         self.assertRaises(IndexError, lambda: po.sections[2])
         self.assertRaises(IndexError, lambda: po.missing_sections[0])
 
+    def test_sections_by_index(self):
+        driver = get_driver()
+        page = """
+        <body>
+            <div class='section'>
+                <div class='token'>t0</div>
+            </div>
+            <div class='section'>
+                <div class='token'>t1</div>
+            </div>
+            <div class='section'>
+                <div class='token'>t2</div>
+            </div>
+            <div class='section'>
+                <div class='token'>t3</div>
+            </div>
+        </body>
+        """
+        uri = make_temp_page(page.strip())
+        po = BasicPageWithSections(driver, uri)
+        self.assertEqual(len(po.sections), 4)
+        self.assertEqual("t0", po.sections[0].tokens[0].text)
+        self.assertEqual("t1", po.sections[1].tokens[0].text)
+        self.assertEqual("t2", po.sections[2].tokens[0].text)
+        self.assertEqual("t3", po.sections[3].tokens[0].text)
+
     def test_sections_list_behavior(self):
         with mock.patch('selenium.webdriver.Firefox') as driver:
             element1, element2 = mock.Mock(), mock.Mock()


### PR DESCRIPTION
The previous implementation of Sections.**getitem** always failed if the index was greater than 1.
