### PR TITLE
`StaleElementReferenceException` added to `WebDriverWait`

### DIFF
--- a/holmium/core/pageobject.py
+++ b/holmium/core/pageobject.py
@@ -11,7 +11,7 @@ import collections
 from functools import wraps
 
 import selenium.webdriver.common.by
-from selenium.common.exceptions import NoSuchElementException
+from selenium.common.exceptions import NoSuchElementException, StaleElementReferenceException
 from selenium.common.exceptions import TimeoutException, NoSuchFrameException
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.remote.webelement import WebElement
@@ -311,7 +311,7 @@ class ElementGetter(object):
                                _meth(self.locator_type, self.query_string)
                            )
 
-                WebDriverWait(self.root, self.timeout).until(callback)
+                WebDriverWait(self.root, self.timeout, ignored_exceptions=[StaleElementReferenceException,]).until(callback)
             except TimeoutException:
                 log.debug(
                     "unable to find element %s after waiting for %d seconds" % (


### PR DESCRIPTION
I've noticed that sometimes [`ElementGetter._get_element`](https://github.com/alisaifee/holmium.core/blob/6d64eadc96fa7e24ac092139cef1dbdf4eb47246/holmium/core/pageobject.py#L276) throws [`selenium.common.exceptions.StaleElementReferenceException`](http://docs.seleniumhq.org/exceptions/stale_element_reference.jsp) exception while waiting for collection of elements which is dynamically changed. 

It's normal `selenium`'s behavior to raise it in such cases and one of common ways to deal with it is just [ignoring it](http://engineeringquality.blogspot.ru/2013/08/ways-of-dealing-with.html). So, I put it into ignore-list.
