### PR TITLE
Don't use __eq__ it's broken in Selenium.

### DIFF
--- a/holmium/core/pageobject.py
+++ b/holmium/core/pageobject.py
@@ -209,7 +209,7 @@ class Page(Faceted):
                     fluent wrapper
                     """
                     resp = attr(*args, **kwargs)
-                    if None == resp:
+                    if resp is None:
                         resp = self
                     return resp
 


### PR DESCRIPTION
If you return a WebElement from a method then you get the following error:

```
Traceback (most recent call last):
...snip...
File "/Users/tirsen/triposo/devel/triposo3/venv/lib/python2.7/site-packages/holmium/core/pageobject.py", line 211, in wrap
  resp = attr(*args, **kwargs)
File "/Users/tirsen/triposo/devel/triposo3/iosguide/automator.py", line 43, in get_next_version_and_status
  return self.get_next_version_element().text.split(' ')
File "/Users/tirsen/triposo/devel/triposo3/venv/lib/python2.7/site-packages/holmium/core/pageobject.py", line 212, in wrap
  if None == resp:
File "/Users/tirsen/triposo/devel/triposo3/venv/lib/python2.7/site-packages/selenium/webdriver/remote/webelement.py", line 351, in __eq__
  if self._id == element.id:
AttributeError: 'NoneType' object has no attribute 'id'
```

This is because the Selenium WebElement class `__eq__` method can't handle being called with `None`. (I don't think it's implemented correctly.)

It's much safer to check for None like this.
