### PR TITLE
updated the phantomjs config to include --ssl-protocol=tlsv1

### DIFF
--- a/holmium/core/config.py
+++ b/holmium/core/config.py
@@ -244,7 +244,7 @@ class PhantomConfig(DriverConfig):
     def __call__(self, config, args):
         if config.ignore_ssl:
             args.setdefault("service_args", []).append(
-                "--ignore-ssl-errors=true")
+                "--ignore-ssl-errors=true --ssl-protocol=tlsv1")
         return super(PhantomConfig, self).__call__(config, args)
 
 class IeConfig(DriverConfig):


### PR DESCRIPTION
When I was testing the holmium against the phantomJS [V1.9.7/1.9.8] , it's unable to find the elements in couple of sites including zopim because of SSL cert issue .

google.com , abc.go.com works fine but accounts.zopim.com, zopim.com,yahoo.com fails 


existing code:

class PhantomConfig(DriverConfig):
    """
    configuration for phantomjs
    """
  def __call__(self, config, args):
        if config.ignore_ssl:
            args.setdefault("service_args", []).append(
                "--ignore-ssl-errors=true")
        return super(PhantomConfig, self).__call__(config, args)


changes requires for 1.9.7 and 1.9.8:

class PhantomConfig(DriverConfig):
    """
    configuration for phantomjs
    """
  def __call__(self, config, args):
        if config.ignore_ssl:
            args.setdefault("service_args", []).append(
                "--ignore-ssl-errors=true --ssl-protocol=tlsv1 ")
        return super(PhantomConfig, self).__call__(config, args)



When I install the PhantomJS 2.0.0 existing code works fine. Suggest if we need to change the holmium core to support 1.9.7 and 1.9.8.   

Please note that phantomJS2.0.0 release is not available for the Linux platform. I have compiled developer release to test 2.0.0.


Reference for the issue:

https://github.com/ariya/phantomjs/issues/10389
http://stackoverflow.com/questions/12021578/phantomjs-failing-to-open-https-site