### PR TITLE
Make setup.py compatible with python 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 import os
 import sys
 this_dir = os.path.abspath(os.path.dirname(__file__))
-REQUIREMENTS = filter(None, open(os.path.join(this_dir, 'requirements/main.txt')).read().splitlines())
+REQUIREMENTS = open(os.path.join(this_dir, 'requirements/main.txt'), 'rt').read()
 
 import versioneer
 versioneer.versionfile_source = "holmium/core/_version.py"


### PR DESCRIPTION
setup.py does not work correctly with REQUIREMENTS on python3.4, because "filter" returns a filter object and not a list as in python 2.7. The filter object is not compatible with setup.py. 

The following pull fixes installation under python 3.4 by correctly handling requirements, whilst maintaining backwards compatibility with older pythons. 

Also, please consider (not included in this diff) wrapping setup.py in an:
  if __name__ == '__main__':

block, so code analaysis tools don't try to install the package while importing for analysis.

Thanks,
Tim