### PR TITLE
Filter condition

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -310,27 +310,24 @@ the text attribute of the element. The same type of lookup functions are used in
 
 Conditions
 ==========
-For any non-trivial web page, asynchronous changes to the dom are expected. This
-requires test authors to often place explicit waits for conditions such as visibility
-and content changes. To reduce the effort of describing these conditionals, page elements
-:class:`Element`, :class:`Elements` and :class:`ElementMap` accept a keyword argument ``only_if``:
-a callable that expects a :class:`selenium.webdriver.remote.webelement.WebElement` and is
-expected to return ``True/False``. When coupled with the keyword argument ``timeout``,
-access to a page object's element is internally subjected to an explicit wait.
-
-Some common conditions are provided and can be used to further simplify the declaration of pageobject:
+Changes to the dom, such as element visibility and content, are expected for any non-trivial web page.
+Page elements :class:`Element`, :class:`Elements`, and :class:`ElementMap` accept a keyword argument
+``filter_by``: a callable that expects a :class:`selenium.webdriver.remote.webelement.WebElement` and
+is expected to return ``True/False``. In :class:`Elements` and :class:`ElementMap`, only elements
+that meet the ``filter_by`` condition will be included in the collection. If the ``filter_by``
+condition is not met in :class:`Element`, ``None`` will be returned. Some common conditions are
+provided:
 
 .. currentmodule:: holmium.core.conditions
 .. autoclass:: VISIBLE
 .. autoclass:: INVISIBLE
 .. autoclass:: MATCHES_TEXT
-.. autoclass:: ANY
-.. autoclass:: ALL
 .. currentmodule:: holmium.core
 
-
-You can build your own condition objects by subclassing :class:`conditions.BaseCondition`
-and implementing the :meth:`conditions.BaseCondition.evaluate` method.
+These conditions can also be used to place explicit waits on elements expected to change
+asynchronously by pairing the ``only_if`` keyword argument with ``timeout``. In :class:`Element`,
+``only_if`` is also a callable that expects a :class:`selenium.webdriver.remote.webelement.WebElement`
+and is expected to return ``True/False``.
 
 Sample
 ------
@@ -347,12 +344,22 @@ Sample
                                     only_if=conditions.MATCHES_TEXT('^ready.*'),
                                     timeout = 5)
 
-
-
 In the above example, ``required_element`` will return ``None`` unless it is displayed. The 5 second
-timeout will take effect everytime the element is accessed. Similarly, ``delayed_element`` will return
+timeout will take effect every time the element is accessed. Similarly, ``delayed_element`` will return
 ``None`` until the text of the element matches a string that starts with ``ready``.
 
+``only_if`` and ``timeout`` explicit waits can also be used with :class:`Elements` and
+:class:`ElementMap`. In these element collections, ``only_if`` expects a list of
+:class:`selenium.webdriver.remote.webelement.WebElement` items and is also expected to return
+``True/False``.  These common conditions for use with element collections are provided:
+
+.. currentmodule:: holmium.core.conditions
+.. autoclass:: ANY
+.. autoclass:: ALL
+.. currentmodule:: holmium.core
+
+You can build your own condition objects by subclassing :class:`conditions.BaseCondition`
+and implementing the :meth:`conditions.BaseCondition.evaluate` method.
 
 Context Managers
 ----------------

--- a/tests/pageelement_tests.py
+++ b/tests/pageelement_tests.py
@@ -51,9 +51,7 @@ class ElementTest(unittest.TestCase):
         assert page.elements[0].text == "simple_id"
         assert page.elements[1].text == "simple_class"
 
-
     def test_basic_element_with_only_if(self):
-
         class SimplePage(Page):
             id_el = Element(Locators.ID, "simple_id")
             id_el_changed = Element(Locators.ID, "simple_id", timeout=10,
@@ -70,3 +68,13 @@ class ElementTest(unittest.TestCase):
         self.driver.refresh()
         with hiro.Timeline().scale(10):
             self.assertEqual(page.id_el_changed, None)
+
+    def test_basic_element_with_filter_by(self):
+        class SimplePage(Page):
+            id_el = Element(Locators.ID, "simple_id", filter_by=lambda el: el.text == "simple_id")
+            id_el_none = Element(Locators.ID, "simple_id", filter_by=lambda el: el.text == "changed")
+
+        uri = make_temp_page(ElementTest.page_content)
+        page = SimplePage(self.driver, uri)
+        assert page.id_el.text == "simple_id"
+        assert page.id_el_none is None

--- a/tests/pageelementmap_tests.py
+++ b/tests/pageelementmap_tests.py
@@ -75,3 +75,19 @@ class ElementMapTest(unittest.TestCase):
             self.assertEqual(page.el_list, {})
             self.assertEqual(len(page.el_list_wait), 1)
             self.assertEqual(len(page.el_list_only_if), 1)
+
+    def test_elements_false_filter_by(self):
+        class SimplePage(Page):
+            el_list_only_if = ElementMap(
+                Locators.CLASS_NAME, "elements",
+                filter_by=lambda el: el.text != "element_text")
+
+        uri = make_temp_page("""
+            <body>
+                <div class="elements">
+                        element_text
+                    </div>
+            </body>
+        """)
+        page = SimplePage(self.driver, uri)
+        self.assertEqual(page.el_list_only_if, {})

--- a/tests/pageelements_tests.py
+++ b/tests/pageelements_tests.py
@@ -1,6 +1,6 @@
 import unittest
 import hiro
-from holmium.core import Elements, Element, Locators, Page
+from holmium.core import Elements, Element, Locators, Page, conditions
 from tests.utils import get_driver, make_temp_page
 
 
@@ -81,3 +81,58 @@ class ElementsTest(unittest.TestCase):
             self.assertEqual(page.el_list, [])
             self.assertEqual(len(page.el_list_wait), 1)
             self.assertEqual(len(page.el_list_only_if), 1)
+
+    def test_basic_element_with_filter_by(self):
+        class SimplePage(Page):
+            el_list_default = Elements(Locators.CLASS_NAME, "simple_class", filter_by=conditions.VISIBLE())
+            el_list_valuemapper = Elements(Locators.CLASS_NAME, "simple_class",
+                                           value=lambda el: el.find_element_by_tag_name("a").text,
+                                           filter_by=conditions.VISIBLE())
+            el_list_valuemapper_complex = Elements(Locators.CLASS_NAME, "simple_class",
+                                                   value=lambda el: {"link": el.find_element_by_tag_name("a").get_attribute("href"),
+                                                                     "text": el.find_element_by_tag_name("a").text},
+                                                   filter_by=conditions.VISIBLE())
+            first_el = Element(Locators.TAG_NAME, "a", base_element=el_list_default[0])
+
+        uri = make_temp_page("""
+            <body>
+                <div class="simple_class">
+                    simple class el 1
+                    <a href="http://el1.com/">element 1</a>
+                </div>
+                <div class="simple_class">
+                    simple class el 2
+                    <a href="http://el2.com/">element 2</a>
+                </div>
+                <div class="simple_class" style="display:none;">
+                    simple class el 3
+                    <a href="http://el3.com/">element 3</a>
+                </div>
+            </body>
+        """)
+        page = SimplePage(self.driver, uri)
+        self.assertEqual([k.text for k in page.el_list_default],
+                          ["simple class el 1 element 1",
+                           "simple class el 2 element 2"])
+        self.assertEqual(page.el_list_valuemapper,
+                          ["element 1", "element 2"])
+        self.assertEqual(page.el_list_valuemapper_complex,
+                          [{"link": "http://el1.com/", "text": "element 1"},
+                           {"link": "http://el2.com/", "text": "element 2"}])
+        self.assertEqual(page.first_el.text, "element 1")
+
+    def test_elements_false_filter_by(self):
+        class SimplePage(Page):
+            el_list_filter_by = Elements(
+                Locators.CLASS_NAME, "elements",
+                filter_by=lambda el: el.text != "element_text")
+
+        uri = make_temp_page("""
+            <body>
+                <div class="elements">
+                        element_text
+                    </div>
+            </body>
+        """)
+        page = SimplePage(self.driver, uri)
+        self.assertEqual(page.el_list_filter_by, [])


### PR DESCRIPTION
1. Add a `FILTER` condition for `Elements` and `ElementMap`. There are instances where you only want a subset of elements that match a query string. `FILTER` will only include the elements in a collection that match the specified condition.
2. Decouple `only_if` from `timeout`. Intuitively `only_if` functions as a filter; it should be applicable beyond the scope of defining explicit waits for asynchronous dom changes.