### PR TITLE
Drop the `element` arg in  assertConditionWithWait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
     - "3.4"
 
 install:
-    - pip install -r requirements/ci.txt --use-mirrors
+    - pip install -r requirements/ci.txt
 
 script:
     - nosetests tests --with-cov -v

--- a/holmium/core/testcase.py
+++ b/holmium/core/testcase.py
@@ -145,4 +145,4 @@ class TestCase(unittest.TestCase):
             wait.until(condition)
         except TimeoutException:
             _msg = self._formatMessage(msg, "Timeout waiting on condition %s" % condition)
-            self.failureException(_msg)
+            raise self.failureException(_msg)

--- a/holmium/core/testcase.py
+++ b/holmium/core/testcase.py
@@ -1,7 +1,10 @@
 """
 the testcase base class
 """
-import unittest
+try:
+	import unittest2 as unittest
+except ImportError:
+	import unittest
 import inspect
 import imp
 import json

--- a/holmium/core/testcase.py
+++ b/holmium/core/testcase.py
@@ -132,19 +132,17 @@ class TestCase(unittest.TestCase):
         self.assertEqual(_expected, element.size, msg)
 
 
-    def assertConditionWithWait(self, driver, condition, element,
-                                timeout=0, msg=None):
+    def assertConditionWithWait(self, driver, condition, timeout=0, msg=None):
         # pylint:disable=line-too-long
         """ Fail if the condition specified does not hold for the element within
         the specified timeout
 
         :param driver: the selenium driver
         :param condition: an instance of :mod:`selenium.webdriver.support.expected_conditions`
-        :param element: the :class:`selenium.webdriver.remote.webelement.WebElement`
         """
         try:
             wait = WebDriverWait(driver, timeout)
-            wait.until(condition(element))
+            wait.until(condition)
         except TimeoutException:
             _msg = self._formatMessage(msg, "Timeout waiting on condition %s" % condition)
             self.failureException(_msg)

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,2 +1,3 @@
 -r test.txt
 python-coveralls
+unittest2; python_version < '2.7'

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,9 @@ if __name__ == "__main__":
     this_dir = os.path.abspath(os.path.dirname(__file__))
     REQUIREMENTS = open(os.path.join(this_dir, 'requirements/main.txt'), 'rt').read()
 
+    if sys.version_info[:2] < (2, 7):
+	    REQUIREMENTS += 'unittest2\n'
+
     import versioneer
     versioneer.versionfile_source = "holmium/core/_version.py"
     versioneer.versionfile_build = "holmium/core/version.py"

--- a/tests/testcase_assertion_tests.py
+++ b/tests/testcase_assertion_tests.py
@@ -107,7 +107,7 @@ class TestCaseTests(unittest.TestCase):
             lambda s: s.assertConditionWithWait(s.driver, lambda _: True),
             lambda s: s.assertConditionWithWait(s.driver,
                                                 fail_first(),
-                                                timeout=1),
+                                                timeout=2),
             lambda s: s.assertConditionWithWait(s.driver,
                                                 lambda _: _ is s.driver)
         ]

--- a/tests/testcase_assertion_tests.py
+++ b/tests/testcase_assertion_tests.py
@@ -80,3 +80,40 @@ class TestCaseTests(unittest.TestCase):
             ]
             runtc({"HO_BROWSER": "firefox"}, validations,
                   validator=lambda c,s: s.assertRaises(AssertionError, c, s ))
+
+    @mock.patch.dict('holmium.core.testcase.BROWSER_MAPPING',
+                     build_mock_mapping('firefox'))
+    def test_assert_condition_with_wait(self):
+        class fail_first(object):
+            first = True
+
+            def __call__(self, driver):
+                # fail first
+                if self.first:
+                    self.first = False
+                    return False
+
+                # pass later
+                return True
+
+        raised_validations = [
+            lambda s: s.assertConditionWithWait(s.driver, lambda _: False),
+            lambda s: s.assertConditionWithWait(s.driver,
+                                                fail_first(),
+                                                timeout=0)
+        ]
+
+        not_raised_validations = [
+            lambda s: s.assertConditionWithWait(s.driver, lambda _: True),
+            lambda s: s.assertConditionWithWait(s.driver,
+                                                fail_first(),
+                                                timeout=1),
+            lambda s: s.assertConditionWithWait(s.driver,
+                                                lambda _: _ is s.driver)
+        ]
+
+        runtc({"HO_BROWSER": "firefox"}, raised_validations,
+              validator=lambda c, s: s.assertRaises(AssertionError, c, s))
+
+        runtc({"HO_BROWSER": "firefox"}, not_raised_validations,
+              validator=lambda c, s: c(s))


### PR DESCRIPTION
`condition` is now passed directly to `WebDriverWait.until`. Also fixes the issue where `self.failureException` is not thrown at all.

Fixes: #40