### PR TITLE
Add ignored_exceptions and improve msg for assertConditionWithWait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.log
+*.swp
 cover/*
 .coverage*
 .test_env

--- a/holmium/core/testcase.py
+++ b/holmium/core/testcase.py
@@ -143,11 +143,14 @@ class TestCase(unittest.TestCase):
 
         :param driver: the selenium driver
         :param condition: an instance of :mod:`selenium.webdriver.support.expected_conditions`
+        :param msg: the failure message when timeout, could be a string or a callable without arguments that returns a string
         """
         try:
             wait = WebDriverWait(driver, timeout,
                                  ignored_exceptions=ignored_exceptions)
             wait.until(condition)
         except TimeoutException:
-            _msg = self._formatMessage(msg, "Timeout waiting on condition %s" % condition)
+            _msg = self._formatMessage(
+                msg() if callable(msg) else msg,
+                "Timeout waiting on condition %s" % condition)
             raise self.failureException(_msg)

--- a/holmium/core/testcase.py
+++ b/holmium/core/testcase.py
@@ -144,6 +144,9 @@ class TestCase(unittest.TestCase):
         :param driver: the selenium driver
         :param condition: an instance of :mod:`selenium.webdriver.support.expected_conditions`
         :param msg: the failure message when timeout, could be a string or a callable without arguments that returns a string
+        :param timeout: to be passed to `selenium.webdriver.support.wait.WebDriverWait`
+        :param ignored_exceptions: to be passed to `selenium.webdriver.support.wait.WebDriverWait`
+
         """
         try:
             wait = WebDriverWait(driver, timeout,

--- a/holmium/core/testcase.py
+++ b/holmium/core/testcase.py
@@ -135,7 +135,8 @@ class TestCase(unittest.TestCase):
         self.assertEqual(_expected, element.size, msg)
 
 
-    def assertConditionWithWait(self, driver, condition, timeout=0, msg=None):
+    def assertConditionWithWait(self, driver, condition, timeout=0, msg=None,
+                                ignored_exceptions=None):
         # pylint:disable=line-too-long
         """ Fail if the condition specified does not hold for the element within
         the specified timeout
@@ -144,7 +145,8 @@ class TestCase(unittest.TestCase):
         :param condition: an instance of :mod:`selenium.webdriver.support.expected_conditions`
         """
         try:
-            wait = WebDriverWait(driver, timeout)
+            wait = WebDriverWait(driver, timeout,
+                                 ignored_exceptions=ignored_exceptions)
             wait.until(condition)
         except TimeoutException:
             _msg = self._formatMessage(msg, "Timeout waiting on condition %s" % condition)


### PR DESCRIPTION
This PR adds two things to `assertConditionWithWait`:

* Add `ignored_exceptions` param that gets passed to `WebDriverWait`
* Update `msg` param to also accepts a callable. This allows us to delay the evaluation of `msg` when its value depends on some selenium elements that change over time