### PR TITLE
Import ABC from collections.abc for Python 3.10 compatibility.

### DIFF
--- a/holmium/core/pageobject.py
+++ b/holmium/core/pageobject.py
@@ -26,6 +26,11 @@ if hasattr(collections, "OrderedDict"):
 else:
     from ordereddict import OrderedDict  # pragma: no cover
 
+try:
+    from collections.abc import Sequence  # pragma: no cover
+except ImportError:
+    from collections import Sequence  # pragma: no cover
+
 from .facets import Faceted, ElementFacet, CopyOnCreateFacetCollectionMeta
 from .logger import log
 
@@ -628,7 +633,7 @@ class Section(Faceted):
         self.__root_val = val
 
 
-class Sections(Section, collections.Sequence):
+class Sections(Section, Sequence):
     """
     Base class for an Iterable view of a collection of
     :class:`holmium.core.Section` objects.


### PR DESCRIPTION
Fixes #46 regarding collections deprecations since Python 3.10 raises ImportError .